### PR TITLE
Change scope attribute to Optional[str] in NotationInfo

### DIFF
--- a/examples/foo.v
+++ b/examples/foo.v
@@ -1,5 +1,6 @@
 From Coq Require Import Lia.
 From Coq Require Import ssreflect ssrbool.
+
 Theorem t:
     forall n: nat, 1 + n > n.
 Proof.
@@ -13,4 +14,20 @@ Proof. by elim: n => //= ? ->. Qed.
 Lemma addnAC n m l : n + m + l = m + (n + l).
 Proof.
   by elim : n => //= ? ->.
+Qed.
+
+Notation "x ⊕ y" := (x + y) (at level 50, left associativity).
+
+Lemma use_notation_wo_scope : 1 ⊕ 2 = 3.
+Proof.
+  reflexivity.
+Qed.
+
+Declare Scope my_scope.
+Notation "x ⊕_s y" := (x + y) (at level 50, left associativity): my_scope.
+Open Scope my_scope.
+
+Lemma use_notation_w_scope : 1 ⊕_s 2 = 3.
+Proof.
+  reflexivity.
 Qed.

--- a/examples/foo.v
+++ b/examples/foo.v
@@ -1,6 +1,5 @@
 From Coq Require Import Lia.
 From Coq Require Import ssreflect ssrbool.
-
 Theorem t:
     forall n: nat, 1 + n > n.
 Proof.

--- a/pytanque/protocol.atd
+++ b/pytanque/protocol.atd
@@ -137,7 +137,7 @@ type notation_info = {
     path: string;
     secpath: string;
     notation: string;
-    scope: string;
+    scope: string nullable;
 }
 
 type list_notations_params = {

--- a/pytanque/protocol.py
+++ b/pytanque/protocol.py
@@ -950,7 +950,7 @@ class NotationInfo:
     path: str
     secpath: str
     notation: str
-    scope: str
+    scope: Optional[str]
 
     @classmethod
     def from_json(cls, x: Any) -> "NotationInfo":
@@ -977,7 +977,7 @@ class NotationInfo:
                     else _atd_missing_json_field("NotationInfo", "notation")
                 ),
                 scope=(
-                    _atd_read_string(x["scope"])
+                    _atd_read_nullable(_atd_read_string)(x["scope"])
                     if "scope" in x
                     else _atd_missing_json_field("NotationInfo", "scope")
                 ),
@@ -991,7 +991,7 @@ class NotationInfo:
         res["path"] = _atd_write_string(self.path)
         res["secpath"] = _atd_write_string(self.secpath)
         res["notation"] = _atd_write_string(self.notation)
-        res["scope"] = _atd_write_string(self.scope)
+        res["scope"] = _atd_write_nullable(_atd_write_string)(self.scope)
         return res
 
     @classmethod

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -167,6 +167,19 @@ class TestNotationListing:
             # Should find at least the + and = notations
             assert any(item.notation == "_ + _" for item in notations)
 
+    def test_list_notations_scope(self, server_config, example_files, petanque_server):
+        """Test notation listing behavior with respect to scopes."""
+        with Pytanque("127.0.0.1", 8765) as client:
+            state = client.start("./examples/foo.v", 'use_notation_wo_scope')
+            notations = client.list_notations_in_statement(state, "Lemma use_notation_wo_scope : 1 ⊕ 2 = 3.")
+            # The ⊕ notation does not belong to a scope.
+            assert notations[0].scope is None
+
+            state = client.start("./examples/foo.v", 'use_notation_w_scope')
+            notations = client.list_notations_in_statement(state, "Lemma use_notation_w_scope : 1 ⊕_s 2 = 3.")
+            # The ⊕_s notation belongs to the 'my_scope' scope.
+            assert notations[0].scope == 'my_scope'
+
     def test_list_notations_complex(
         self, server_config, example_files, petanque_server
     ):


### PR DESCRIPTION
Hello, 

`petanque/list_notations_in_statement` can return notation_info entries with `"scope": null`.
While `NotationInfo` types `scope` as `str` and calls `_atd_read_string`, which may raise:
`ValueError: incompatible JSON value where type 'str' was expected: 'None'`


Reproduction:

```coq
From Stdlib Require Import Arith.

Notation "x ⊕ y" := (x + y) (at level 50, left associativity).

Lemma use_notation : 1 ⊕ 2 = 3.
Proof.
  reflexivity.
Qed.
```

```python
from pytanque import Pytanque

with Pytanque('127.0.0.1', 8765) as client:
    state = client.start( 'test.v', "use_notation")
    notations = client.list_notations_in_statement(state, "Lemma use_notation : 1 ⊕ 2 = 3.")
```

Fix: 
- Change NotationInfo.scope to Optional[str] and adapt from_json method